### PR TITLE
Feature/multiple validators

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,5 +28,8 @@
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+  },
+  "resolutions": {
+    "iron-validatable-behavior": "feature/multipleValidators"
   }
 }

--- a/iron-native-validator.html
+++ b/iron-native-validator.html
@@ -1,0 +1,112 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="iron-validator-behavior.html">
+
+<!--
+`<iron-native-validator>` is a an instantiation of a validator implementing the native
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/ValidityState">ValidityState API</a>.
+
+It maps native validators 'required', 'max', 'min', 'step', 'maxlength', 'minlength', 'pattern',
+'emailtype'(type=email) and 'urltype' (type=url) to the validity state
+
+    <iron-native-validator validator-name="required" message="Please fill in a value" id="instance"></iron-native-validator>
+    <iron-native-validator validator-name="emailtype" message="Please enter a valid e-mail address"></iron-native-validator>
+
+These native validators need to be instantiated once, so they are ready for use on a global level.
+The configured messages will be exposed by the validatable element, and will by default be shown via the paper-input.
+
+# Shimming
+When the native ValidityState API doesn't work (yet) in a certain browser, it is possible to provide your own validity
+method.
+
+@group Iron Elements
+@element iron-native-validator
+@hero hero.svg
+@demo demo/index.html
+-->
+
+<dom-module id="iron-native-validator">
+
+    <script>
+
+        (function () {
+
+            var validityFns = {};
+
+            Polymer({
+
+                is: 'iron-native-validator',
+
+                behaviors: [
+                    Polymer.IronValidatorBehavior
+                ],
+
+                properties: {
+                    /**
+                     * Namespace for this validator, override of default 'validator'
+                     */
+                    validatorType: {
+                        type: String,
+                        value: 'native-validator'
+                    },
+
+                    /**
+                     * Maps native validity API to native validator names
+                     */
+                    validityApiMapping: {
+                        type: Object,
+                        readOnly: true,
+                        value: function () {
+                            return {
+                                required: 'valueMissing',
+                                pattern: 'patternMismatch',
+                                max: 'rangeOverflow',
+                                min: 'rangeUnderflow',
+                                step: 'stepMismatch',
+                                maxlength: 'tooLong',
+                                minlength: 'tooShort',
+                                emailtype: 'typeMismatch',
+                                urltype: 'typeMismatch'
+                            };
+                        }
+                    }
+
+                },
+
+                ready: function () {
+                    // Use native validity API for every validator
+                    var mapping = this.validityApiMapping;
+                    Object.keys(mapping).forEach(function (validator) {
+                        validityFns[validator] = function (value, input) {
+                            return !input.validity[mapping[validator]];
+                        };
+                    }, this);
+                },
+
+                validate: function (value, input) {
+                    return validityFns[this.validatorName](value, input);
+                },
+
+                /* For (globally) overriding the validation method of a native validator.
+                 Should only be used when native validity API doesn't work (yet) in a certain browser
+                 */
+                overrideValidationMethod: function (validator, fn) {
+                    validityFns[validator] = fn.bind(this);
+                }
+
+            });
+
+        }());
+
+    </script>
+
+</dom-module>

--- a/iron-validator-behavior.html
+++ b/iron-validator-behavior.html
@@ -13,49 +13,57 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  /**
-   * Use `Polymer.IronValidatorBehavior` to implement a custom input/form validator. Element
-   * instances implementing this behavior will be registered for use in elements that implement
-   * `Polymer.IronValidatableBehavior`.
-   * 
-   * @demo demo/index.html
-   * @polymerBehavior
-   */
-  Polymer.IronValidatorBehavior = {
-
-    properties: {
-
-      /**
-       * Namespace for this validator.
-       */
-      validatorType: {
-        type: String,
-        value: 'validator'
-      },
-
-      /**
-       * Name for this validator, used by `Polymer.IronValidatableBehavior` to lookup this element.
-       */
-      validatorName: {
-        type: String,
-        value: function() {
-          return this.is;
-        }
-      }
-
-    },
-
-    ready: function() {
-      new Polymer.IronMeta({type: this.validatorType, key: this.validatorName, value: this});
-    },
-
     /**
-     * Implement custom validation logic in this function.
-     * @param {Object} values The value to validate. May be any type depending on the validation logic.
-     * @return {Boolean} true if `values` is valid.
+     * Use `Polymer.IronValidatorBehavior` to implement a custom input/form validator. Element
+     * instances implementing this behavior will be registered for use in elements that implement
+     * `Polymer.IronValidatableBehavior`.
+     *
+     * @demo demo/index.html
+     * @polymerBehavior
      */
-    validate: function(values) {
-    }
-  };
+    Polymer.IronValidatorBehavior = {
+
+        properties: {
+
+            /**
+             * Namespace for this validator.
+             */
+            validatorType: {
+                type: String,
+                value: 'validator'
+            },
+
+            /**
+             * Name for this validator, used by `Polymer.IronValidatableBehavior` to lookup this element.
+             */
+            validatorName: {
+                type: String,
+                value: function () {
+                    return this.is;
+                }
+            },
+
+            /**
+             * Default error message for the validator implementing the IronValidatorBehavior
+             */
+            message: {
+                type: String,
+                value: ''
+            }
+
+        },
+
+        ready: function () {
+            new Polymer.IronMeta({type: this.validatorType, key: this.validatorName, value: this});
+        },
+
+        /**
+         * Implement custom validation logic in this function.
+         * @param {Object} values The value to validate. May be any type depending on the validation logic.
+         * @return {Boolean} true if `values` is valid.
+         */
+        validate: function (values) {
+        }
+    };
 
 </script>

--- a/iron-validator-behavior.html
+++ b/iron-validator-behavior.html
@@ -69,9 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         /**
          * Implement custom validation logic in this function.
          * @param {Object} values The value to validate. May be any type depending on the validation logic.
+         * @param {HTMLElement} The element validation is being applied to. When a native validation API is present
+         * (like for instance on the HTMLinputElement), native validation can be used inside the validate function of the validator.
          * @return {Boolean} true if `values` is valid.
          */
-        validate: function (values) {
+        validate: function (values, input) {
         }
     };
 

--- a/iron-validator-behavior.html
+++ b/iron-validator-behavior.html
@@ -49,12 +49,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             message: {
                 type: String,
                 value: ''
+            },
+
+            /**
+             * Used to connect the custom validator instance to the desired validatable via the property `validatableId`.
+             */
+            'for': {
+                type: String,
+                value: ''
             }
 
         },
 
         ready: function () {
-            new Polymer.IronMeta({type: this.validatorType, key: this.validatorName, value: this});
+            var suffix = this.for ? ('--' + this.for) : '';
+            new Polymer.IronMeta({type: this.validatorType, key: this.validatorName + suffix, value: this});
         },
 
         /**

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'iron-validator-behavior.html',
-        'iron-validator-behavior.html?dom=shadow'
+        'iron-native-validator.html',
+        'iron-validator-behavior.html?dom=shadow',
+        'iron-native-validator.html?dom=shadow'
       ]);
     </script>
 

--- a/test/iron-native-validator.html
+++ b/test/iron-native-validator.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+    <title>iron-validatable-behavior tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+
+    <link rel="import" href="../../iron-validatable-behavior/iron-validatable-behavior.html">
+    <link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+    <link rel="import" href="../iron-native-validator.html">
+
+
+</head>
+<body>
+
+<test-fixture id="native-instances">
+    <template>
+        <div>
+            <iron-native-validator validator-name="required" message="required" id="instance"></iron-native-validator>
+            <iron-native-validator validator-name="max" message="max"></iron-native-validator>
+            <iron-native-validator validator-name="min" message="min"></iron-native-validator>
+            <iron-native-validator validator-name="step" message="step"></iron-native-validator>
+            <iron-native-validator validator-name="maxlength" message="maxlength"></iron-native-validator>
+            <iron-native-validator validator-name="minlength" message="minlength"></iron-native-validator>
+            <iron-native-validator validator-name="pattern" message="pattern"></iron-native-validator>
+            <iron-native-validator validator-name="emailtype" message="emailtype"></iron-native-validator>
+            <iron-native-validator validator-name="urltype" message="urltype"></iron-native-validator>
+        </div>
+    </template>
+</test-fixture>
+
+<test-fixture id="inputs">
+    <template>
+        <div>
+            <input validator="required" required value="">
+            <input validator="max" max="100" type="number" value="200">
+            <input validator="min" min="50" type="number" value="25">
+            <input validator="emailtype" type="email" value="nonsense">
+            <input validator="urltype" type="url" value="nonsense">
+            <input validator="step" step="3" type="number" value="2" wrong-value="1">
+            <input validator="pattern" pattern="[A-Za-z]{3}" value="nonsense">
+            <input validator="minlength" maxlength="2" value="123">
+            <input validator="maxlength" minlength="2" value="1">
+        </div>
+    </template>
+</test-fixture>
+
+<script>
+
+    suite('basic', function() {
+
+        test('registers as type \'native-validator\' ', function() {
+            var nativeInstance = fixture('native-instances').querySelector('iron-native-validator');
+            assert.equal(nativeInstance.validatorType, 'native-validator');
+        });
+
+        test('uses native validity API', function() {
+            var inputs = fixture('inputs');
+            var nativeValidators = fixture('native-instances');
+            var mapping = nativeValidators.querySelector('iron-native-validator').validityApiMapping;
+
+            Object.keys(mapping).forEach(function (v) {
+                var validator = nativeValidators.querySelector('[validator-name="' + v + '"]');
+                var input = inputs.querySelector('[validator="' + v + '"]');
+                assert.equal(validator.validate(input.value, input), !input.validity[mapping[v]]);
+            });
+        });
+
+        test('can have overridden validation methods', function() {
+            var maxlengthValidator = fixture('native-instances').querySelector('[validator-name="maxlength"]');
+            var newMethod = sinon.spy();
+            maxlengthValidator.overrideValidationMethod('maxlength', newMethod);
+            maxlengthValidator.validate();
+            assert(newMethod.called);
+        });
+
+    });
+
+
+</script>
+
+</body>

--- a/test/iron-validator-behavior.html
+++ b/test/iron-validator-behavior.html
@@ -31,6 +31,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="target-specified">
+    <template>
+      <simple-validator for="validatableTarget"></simple-validator>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
@@ -38,6 +44,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('registered in <iron-meta>', function() {
         fixture('basic');
         assert.ok(new Polymer.IronMeta({type: 'validator'}).byKey('simple-validator'), 'simple-validator found in <iron-meta>');
+      });
+
+      test('registered in <iron-meta> as specific validation', function() {
+        fixture('target-specified');
+        assert.ok(new Polymer.IronMeta({
+          type: 'validator'
+        }).byKey('simple-validator--validatableTarget'), 'simple-validator found in <iron-meta>');
       });
 
     });


### PR DESCRIPTION
Currently, it's not possible to use multiple validators on an input.

Also see:
- https://github.com/PolymerElements/paper-input/issues/289
- https://github.com/PolymerElements/iron-input/issues/53

With this pull request, it will become possible to add multiple validators to elements implementing the validatable behavior, without having to write a new custom validator that combines functionality of other validators. 

Along with this functionality, the following will be supported:
- custom messages: 
  - stored in validators (so there's a single source of truth, resulting in consistency between forms and less development work)
  - support for multiple error messages, ordered by priority (the most important message will be shown by the paper-input)
- support for native validators('required', 'max', 'min', 'step', 'maxlength', 'minlength', 'pattern', 'emailtype'(type=email) and 'urltype' (type=url))
- automatic instantiating of custom validators 
- possibility to connect unique instances of a validator to a validatable-element (when overriding of the default message will be needed)

Everything is tested for backwards compatibility. All tests have run in chrome 51, firefox 46, OS X 10.9 safari 7, OS X 10.10 safari 8, OS X 10.11 safari 9, Windows 7 IE 10, Windows 8.1 IE 11, Windows 10 microsoftedge, Android 4.3, Android 4.4, Android 5, Android 6, iOS 7, iOS 8, iOS 9.3.

Note that, since the validation functionality is located in different repositories, the above functionality will contain pull requests in the following repositories:
- <a href="https://github.com/PolymerElements/iron-validator-behavior/pull/24">iron-validator-behavior</a>
- <a href="https://github.com/PolymerElements/iron-validatable-behavior/pull/28">iron-validable-behavior</a>
- <a href="https://github.com/PolymerElements/iron-input/pull/90">iron-input</a>
- <a href="https://github.com/PolymerElements/paper-input/pull/436">paper-input</a>

The link below shows an example of what would be the benefit of the old vs. the new situation.
It makes clear what the API will look like and how little code will be needed to achieve the same in the new situation.

https://tlouisse.github.io/iron-validatable-behavior/components/iron-validatable-behavior/demo/
