### PR TITLE
Switched back to using validator name as key

### DIFF
--- a/iron-validator-behavior.html
+++ b/iron-validator-behavior.html
@@ -22,8 +22,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @polymerBehavior
    */
   Polymer.IronValidatorBehavior = {
+
+    properties: {
+      /**
+       * Name for this validator, used by `Polymer.IronValidatableBehavior` to lookup this element.
+       */
+      validatorName: {
+        type: String,
+        value: function() {
+          return this.is;
+        }
+      }
+    },
+
     ready: function() {
-      new Polymer.IronMeta({type: 'validator', key: this.is, value: this});
+      new Polymer.IronMeta({type: 'validator', key: this.validatorName, value: this});
     },
 
     /**


### PR DESCRIPTION
As mentioned in #30 the current method of using `this.is` as a key for registering the validator does not work. Here we switch back to providing name until we switch to using a class based mixin to implement the behaviour.