### PR TITLE
Fix issue#30

### DIFF
--- a/iron-validator-behavior.html
+++ b/iron-validator-behavior.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    */
   Polymer.IronValidatorBehavior = {
     ready: function() {
-      new Polymer.IronMeta({type: 'validator', key: this.is, value: this});
+      new Polymer.IronMeta({type: 'validator', key: this.constructor.is, value: this});
     },
 
     /**


### PR DESCRIPTION
In Polymer2 `this.is` doesn't work because `is`  is a static method .
Static methods are not directly accessible using the `this` keyword from non-static methods. You need to call them using the class name: CLASSNAME.STATIC_METHOD_NAME() or by calling the method as a property of the constructor,

that is why something like the following will work
```
class PasProfilePasswordValidator extends Polymer.Element {
      static get is() {return 'pas-profile-password-validator';}
...
      ready() {
        super.ready();
        new Polymer.IronMeta({type: 'validator', key: PasProfilePasswordValidator.is, value: this});
      }
```
a better solution would be to replace `PasProfilePasswordValidator.is` with `this.constructor.is`